### PR TITLE
Fix: Oilrig could be built on coast of small islands.

### DIFF
--- a/src/industries/dredging_site.py
+++ b/src/industries/dredging_site.py
@@ -18,7 +18,7 @@ industry.economy_variations['BASIC_TEMPERATE'].enabled = True
 industry.economy_variations['BASIC_TEMPERATE'].prod_cargo_types_with_multipliers = [('SAND', 17)]
 
 industry.add_tile(id='dredging_site_tile_1',
-                  location_checks=TileLocationChecks(disallow_industry_adjacent=True))
+                  location_checks=TileLocationChecks(disallow_industry_adjacent=True, disallow_slopes=True))
 
 sprite_ground = industry.add_sprite(
     sprite_number='GROUNDSPRITE_WATER',

--- a/src/industries/oil_rig.py
+++ b/src/industries/oil_rig.py
@@ -19,7 +19,7 @@ industry.economy_variations['FIRS'].enabled = True
 industry.economy_variations['IN_A_HOT_COUNTRY'].enabled = True
 
 industry.add_tile(id='oil_rig_tile_1',
-                  location_checks=TileLocationChecks(disallow_industry_adjacent=True))
+                  location_checks=TileLocationChecks(disallow_industry_adjacent=True, disallow_slopes=True))
 
 sprite_ground = industry.add_sprite(
     sprite_number='GROUNDSPRITE_WATER',


### PR DESCRIPTION
industry.py detect if both land_shape_flags and location_checks are defined.
But if only location_checks is defined, it can't figure out whether slopes are intended or unspecified.