### PR TITLE
it-IT: Avoid duplicate terms for Copper

### DIFF
--- a/src/lang/italian.lng
+++ b/src/lang/italian.lng
@@ -38,7 +38,7 @@ STR_CARGO_NAME_CHLORINE                                                         
 STR_CARGO_NAME_CLAY                                                             :{G=f}Argilla
 STR_CARGO_NAME_COFFEE                                                           :{G=m}Caffé
 STR_CARGO_NAME_COKE                                                             :Coke
-STR_CARGO_NAME_COPPER                                                           :Rame
+STR_CARGO_NAME_COPPER                                                           :Rame raffinato
 STR_CARGO_NAME_EDIBLE_OIL                                                       :Olio da cucina
 STR_CARGO_NAME_ENGINEERING_SUPPLIES                                             :{G=f}Forniture meccaniche
 STR_CARGO_NAME_EXPLOSIVES                                                       :Esplosivi
@@ -92,7 +92,7 @@ STR_CARGO_UNIT_CHLORINE                                                         
 STR_CARGO_UNIT_CLAY                                                             :{WEIGHT} di argilla
 STR_CARGO_UNIT_COFFEE                                                           :{SIGNED_WORD} sacc{P 0 o hi} di caffé
 STR_CARGO_UNIT_COKE                                                             :{WEIGHT} di coke
-STR_CARGO_UNIT_COPPER                                                           :{WEIGHT} di rame
+STR_CARGO_UNIT_COPPER                                                           :{WEIGHT} di rame raffinato
 STR_CARGO_UNIT_EDIBLE_OIL                                                       :{VOLUME} di olio da cucina
 STR_CARGO_UNIT_ENGINEERING_SUPPLIES                                             :{SIGNED_WORD} cass{P 0 a e} di forniture meccaniche
 STR_CARGO_UNIT_EXPLOSIVES                                                       :{SIGNED_WORD} cass{P 0 a e} di esplosivi


### PR DESCRIPTION
In the italian translation 'copper ore' (`STR_CARGO_SINGULAR_COPPER_ORE`) and 'copper' (`STR_CARGO_NAME_COPPER`) are both translated as 'Rame' making them indistinguishable in the U.I.

I'd like to change the translation of the refined one in 'Rame raffinato'. I was also thinking about translating it in 'Bobine di rame' or 'Lingotti di rame' but raffinato seems to be the more generic term