### PR TITLE
Change: water industry grounds

### DIFF
--- a/src/industries/bulk_terminal.py
+++ b/src/industries/bulk_terminal.py
@@ -67,7 +67,7 @@ industry.add_tile(
 sprite_ground = industry.add_sprite(sprite_number="GROUNDSPRITE_WATER")
 spriteset_ground_empty = industry.add_spriteset(type="empty")
 spriteset_concrete = industry.add_spriteset(
-    sprites=[(10, 10, 64, 39, -31, -8)],
+    type="dirty_concrete_elevated",
     always_draw=1,
 )
 spriteset_crane_rails_nw_se = industry.add_spriteset(

--- a/src/industries/fish_farm.py
+++ b/src/industries/fish_farm.py
@@ -46,7 +46,7 @@ sprite_ground = industry.add_sprite(
 )
 spriteset_ground_empty = industry.add_spriteset(type="empty")
 spriteset_concrete = industry.add_spriteset(
-    sprites=[(10, 10, 64, 39, -31, -8)],
+    type="dirty_concrete_elevated",
     always_draw=1,
 )
 spriteset_warehouse = industry.add_spriteset(

--- a/src/industries/fishing_harbour.py
+++ b/src/industries/fishing_harbour.py
@@ -52,7 +52,7 @@ industry.add_tile(
 sprite_ground = industry.add_sprite(sprite_number="GROUNDSPRITE_WATER")
 spriteset_ground_empty = industry.add_spriteset(type="empty")
 spriteset_concrete = industry.add_spriteset(
-    sprites=[(10, 10, 64, 39, -31, -8)],
+    type="dirty_concrete_elevated",
     always_draw=1,
 )
 spriteset_jetty_se_nw = industry.add_spriteset(

--- a/src/industries/liquids_terminal.py
+++ b/src/industries/liquids_terminal.py
@@ -40,7 +40,7 @@ industry.add_tile(
 sprite_ground = industry.add_sprite(sprite_number="GROUNDSPRITE_WATER")
 spriteset_ground_empty = industry.add_spriteset(type="empty")
 spriteset_concrete = industry.add_spriteset(
-    sprites=[(10, 10, 64, 39, -31, -8)],
+    type="dirty_concrete_elevated",
     always_draw=1,
 )
 spriteset_jetty_se_nw = industry.add_spriteset(

--- a/src/industries/port.py
+++ b/src/industries/port.py
@@ -91,7 +91,7 @@ industry.add_tile(
 sprite_ground = industry.add_sprite(sprite_number="GROUNDSPRITE_WATER")
 spriteset_ground_empty = industry.add_spriteset(type="empty")
 spriteset_concrete = industry.add_spriteset(
-    sprites=[(10, 10, 64, 39, -31, -8)],
+    type="dirty_concrete_elevated",
     always_draw=1,
 )
 spriteset_jetty_se_nw = industry.add_spriteset(

--- a/src/industries/trading_post.py
+++ b/src/industries/trading_post.py
@@ -40,7 +40,7 @@ industry.add_tile(
 sprite_ground = industry.add_sprite(sprite_number="GROUNDSPRITE_WATER")
 spriteset_ground_empty = industry.add_spriteset(type="empty")
 spriteset_concrete = industry.add_spriteset(
-    sprites=[(10, 10, 64, 39, -31, -8)],
+    type="dirty_concrete_elevated",
     always_draw=1,
 )
 spriteset_jetty_se_nw = industry.add_spriteset(

--- a/src/industries/wharf.py
+++ b/src/industries/wharf.py
@@ -73,7 +73,7 @@ industry.add_tile(
 sprite_ground = industry.add_sprite(sprite_number="GROUNDSPRITE_WATER")
 spriteset_ground_empty = industry.add_spriteset(type="empty")
 spriteset_concrete = industry.add_spriteset(
-    sprites=[(10, 10, 64, 39, -31, -8)],
+    type="dirty_concrete_elevated",
     always_draw=1,
 )
 spriteset_crane_rails_nw_se = industry.add_spriteset(

--- a/src/templates/ground_tiles.pynml
+++ b/src/templates/ground_tiles.pynml
@@ -3,12 +3,27 @@ template tmpl_ground_tile(x, y) {
 	[x, y, 64, 31, -31, 0, ANIM]
 }
 
+template tmpl_ground_tile_elevated(x, y) {
+	[x, y, 64, 31, -31, -8, ANIM]
+}
+
 <tal:spritesets repeat="ground_tile [('mud', 0), ('dirty_concrete', 80), ('hard_standing_dirt', 150), ('cobble', 220), ('snow', 290), ('slab', 360)]">
     <!--! the frame variants are to support animated, they're hard-coded to match current animation amounts and must be extended if industry animations evolve -->
     <tal:frame_variants repeat="frame_count global_constants.animated_ground_tile_frame_counts">
         spriteset(spriteset_ground_tile_${ground_tile[0]}_${frame_count}, "src/graphics/other/ground_tiles.png") {
             <tal:autofill_sprites repeat="autosprite_num range(frame_count)">
                 tmpl_ground_tile(${ground_tile[1]}, 10)
+            </tal:autofill_sprites>
+        }
+    </tal:frame_variants>
+</tal:spritesets>
+
+<tal:spritesets repeat="ground_tile_elevated [('mud_elevated', 0), ('dirty_concrete_elevated', 80), ('hard_standing_dirt_elevated', 150), ('cobble_elevated', 220), ('snow_elevated', 290), ('slab_elevated', 360)]">
+    <!--! the frame variants are to support animated, they're hard-coded to match current animation amounts and must be extended if industry animations evolve -->
+    <tal:frame_variants repeat="frame_count global_constants.animated_ground_tile_frame_counts">
+        spriteset(spriteset_ground_tile_${ground_tile_elevated[0]}_${frame_count}, "src/graphics/other/ground_tiles.png") {
+            <tal:autofill_sprites repeat="autosprite_num range(frame_count)">
+                tmpl_ground_tile_elevated(${ground_tile_elevated[1]}, 10)
             </tal:autofill_sprites>
         }
     </tal:frame_variants>


### PR DESCRIPTION
Graphics are now taken from ground_tiles.png instead of the industry specific graphics. The port, trading post, liquids terminal, fish farm, fishing harbour have all been changed to use dirty concrete for consistensy.